### PR TITLE
Replaced '#' for shell command to ';'.

### DIFF
--- a/_chapters/04-ex1.md
+++ b/_chapters/04-ex1.md
@@ -1,4 +1,4 @@
-# Chapter 1: Let's get printing! 
+# Chapter 1: Let's get printing!
 
 In this exercise, we will familiarise ourselves with the Julia REPL and print a few things.
 
@@ -36,7 +36,9 @@ To leave help mode, use the Backspace key.
 
 Prompt: `shell>`
 
-To execute shell commands, enter `#`. The REPL prompt will change to `shell>`, and anything you enter will be executed as a shell command.
+To execute shell commands, enter `;`. The REPL prompt will change to `shell>`, and anything you enter will be executed as a shell command.
+
+To leave shell mode, use the Backspace key.
 
 #### Search
 
@@ -59,8 +61,8 @@ Using Tab triggers your new best friend, Julia's autocomplete feature. Julia als
 
 Pressing Tab on a LaTeX symbol name autocompletes to Unicode symbols:
 
-    julia> \sqrt[Tab]2 
-    julia> √2 
+    julia> \sqrt[Tab]2
+    julia> √2
     1.4142135623730951
 
 For all Unicode completions, check out [the Unicode conversion table in the Julia documentation](<https://github.com/JuliaLang/julia/blob/master/doc/manual/unicode-input-table.rst). Remember, you can also use Unicode symbols in saved code.


### PR DESCRIPTION
Reference
http://julia.readthedocs.org/en/latest/manual/interacting-with-julia/

Currently, says use '#', which does nothing at the julia> prompt.

Also added a line about using the backspace key, to parallel the same line discussing help mode.
