### PR TITLE
Fedora installation updated

### DIFF
--- a/_chapters/03-ex0.md
+++ b/_chapters/03-ex0.md
@@ -43,8 +43,7 @@ If you're using a *NIX distribution, you might be able to use your distro's pack
 ```
 2. __Fedora__: In Fedora:
 ```
-	sudo dnf copr enable nalimilan/julia
-	sudo yum install julia
+	sudo dnf install -y julia
 ```
 3. __Arch__: Under Arch Linux, simply install the package, which is available
    in the 'community' repository:


### PR DESCRIPTION
Since Fedora already has in its official repos the packages for julia, it can be only needed to run a command to install it. Also it is for the best interest to have a tested package from your distro than chasing the upstream (and fedora maintainers do it anyway).