### PR TITLE
Finish Ch6 `continue` keyword example

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ _The contents of this book, where applicable, represent the author's views or, w
 - [Svaksha](http://svaksha.com/pages/Bio)
 - [Louis Luangkesorn](http://lugerpitt.blogspot.com/)
 - [Bobby Lindsey](https://github.com/bobbywlindsey)
+- [Alessandro Melis](https://github.com/alemelis)
 
 # With thanks to
 

--- a/_chapters/09-ex6.md
+++ b/_chapters/09-ex6.md
@@ -304,14 +304,13 @@ With `while`, we're entering the world of repeated (or _iterative_) evaluation. 
 A `while` loop can be terminated by the `break` keyword prematurely (that is, before it has reached its condition). Thus, the following loop would only be executed five times, not ten:
 
 ```julia
-	while i < 10
+    while i < 10
         i += 1
         println("The value of i is ", i)
         if i == 5
             break
         end
     end
-
 ```
 
 The result is:
@@ -322,7 +321,6 @@ The result is:
 	The value of i is 3
 	The value of i is 4
 	The value of i is 5
-
 ```
 
 This is because after five evaluations, the conditional would have evaluated to true and led to the `break` keyword breaking the loop.
@@ -331,7 +329,30 @@ This is because after five evaluations, the conditional would have evaluated to 
 
 Let's assume we have suffered a grievous blow to our heads and forgotten all we knew about `for` loops and negation. Through some odd twist of fate, we absolutely _need_ to list all non-primes from one to ten, and we need to use a `while` loop for this.
 
-The `continue` keyword instructs a loop to finish evaluating the current value of the iterator and go to the next. As such, you would want to put it as early as possible - there is no use instructing Julia to stop looking at the current iterator when
+The `continue` keyword instructs a loop to finish evaluating the current value of the iterator and go to the next. As such, you would want to put it as early as possible - there is no use instructing Julia to stop looking at the current iterator when other (possibly time consuming) istructions have been already executed. The following loop uses the `continue` keyword to skip a value if it is prime:
+
+```julia
+    i = 0
+    while i < 10
+        i += 1
+        if isprime(i)
+            continue
+        else
+            println(i, " is not a prime number")
+        end
+    end
+```
+
+The result reads:
+
+```julia
+    1 is not a prime number
+    4 is not a prime number
+    6 is not a prime number
+    8 is not a prime number
+    9 is not a prime number
+    10 is not a prime number
+```
 
 ## `for`
 
@@ -346,7 +367,6 @@ Like `while`, `for` is a loop operator. Unlike `while`, it operates not _as long
 	true
 	true
 	false
-
 ```
 
 ### Iterating over indexable collections
@@ -364,13 +384,12 @@ Other iterables include indexable collections:
 	b
 	i
 	v
-
 ```
 
 This includes, incidentally, multidimensional arrays – but don't forget the direction of iteration (column by column, top-down):
 
 ```julia
-	ulia> md_array = [1 1 2 3 5; 8 13 21 34 55; 89 144 233 377 610]
+	julia> md_array = [1 1 2 3 5; 8 13 21 34 55; 89 144 233 377 610]
 	3x5 Array{Int64,2}:
 	  1    1    2    3    5
 	  8   13   21   34   55
@@ -385,7 +404,6 @@ This includes, incidentally, multidimensional arrays – but don't forget the di
 	...
 	55
 	610
-
 ```
 
 ### Iterating over dicts
@@ -403,7 +421,6 @@ In tuple iteration, each key-value pair is seen as a tuple and returned as such:
 	Galton lived 1822-1911.
 	Pearson lived 1857-1936.
 	Gosset lived 1876-1937.
-
 ```
 
 While this does the job, it is not particularly graceful. It is, however, useful if we need to have the key and the value in the same object, such as in the case of conversion scripts often encountered in 'data munging'.


### PR DESCRIPTION
The example for `continue` keyword within a `while` loop was incomplete. A simple script to print non-prime numbers between 1 and 10 has been added.

Additional md format fixes