### PR TITLE
fixed typos in chapter 6

### DIFF
--- a/_chapters/06-ex3.md
+++ b/_chapters/06-ex3.md
@@ -36,7 +36,7 @@ In the context of a _statement_, such as a function, `::` appended to a variable
 	Int8
 ```
 
-As we can see, the `::` within the function had the effect that the returned result would be represented as an 8-bit integer (`Int8`). Recall that this _only works in the context of a statement_ – thus simply entering `x::Int8` will yield a `typeassert` error, telling us that we have provided an integer literal, which Julia understands by default to be an `Int64, to be assigned to a variable and shaped as an `Int8` – which clearly doesn't work.
+As we can see, the `::` within the function had the effect that the returned result would be represented as an 8-bit integer (`Int8`). Recall that this _only works in the context of a statement_ – thus simply entering `x::Int8` will yield a `typeassert` error, telling us that we have provided an integer literal, which Julia understands by default to be an `Int64`, to be assigned to a variable and shaped as an `Int8` – which clearly doesn't work.
 
 ### Asserting a type
 

--- a/_chapters/06-ex3.md
+++ b/_chapters/06-ex3.md
@@ -57,7 +57,7 @@ For instance, you are provided a variable `input_from_user`. How do you make sur
 
 As you can see, if you specify the correct abstract type, you get the value returned, whereas in our second assertion, where we asserted that the value was of the type `Char` (used to store individual characters), we got a `typeassert` error, which we can catch later on and return to ensure that we get the right type of value.
 
-Remember that a type hierarchy is like a Venn diagram. Every `Int64` (a concrete type) is also an `Ìnteger`(an abstract type). Therefore, asserting `input_from_user::Int64` will also yield `128`, while asserting a different concrete type, such as `Int32`, will yield a `typeassert` error. `Int` is just an alias for `Int64`.
+Remember that a type hierarchy is like a Venn diagram. Every `Int64` (a concrete type) is also an `Integer`(an abstract type). Therefore, asserting `input_from_user::Int64` will also yield `128`, while asserting a different concrete type, such as `Int32`, will yield a `typeassert` error. `Int` is just an alias for `Int64`.
 
 ### Specifying acceptable function inputs
 


### PR DESCRIPTION
- an accent was missing after `Int64` in line 39
- `Ìnteger` -> `Integer` in line 60

Edit: added another commit