### PR TITLE
Update of Unicode conversion table link

### DIFF
--- a/_chapters/04-ex1.md
+++ b/_chapters/04-ex1.md
@@ -70,7 +70,7 @@ Pressing the `Tab` key on a LaTeX symbol name autocompletes to Unicode symbols:
     1.4142135623730951
 ```
 
-For all Unicode completions, check out [the Unicode conversion table in the Julia documentation](https://github.com/JuliaLang/julia/blob/master/doc/manual/unicode-input-table.rst). Remember, you can also use Unicode symbols in saved code.
+For all Unicode completions, check out [the Unicode conversion table in the Julia documentation](https://docs.julialang.org/en/latest/manual/unicode-input/#Unicode-Input-1). Remember, you can also use Unicode symbols in saved code.
 
 ## Let's say something!
 


### PR DESCRIPTION
The previous link resulted in a "404 Page not found". Updated link to the table using the latest Julia Lang documentation.