### PR TITLE
Fix comment on types

### DIFF
--- a/_chapters/06-ex3.md
+++ b/_chapters/06-ex3.md
@@ -94,7 +94,7 @@ To obtain the type of a value, use the `typeof()` function:
 	Int64
 ```
 
-`typeof()` is notable for treating tuples differently from most other collections. Calling `typeof()` on a tuple enumerates the types of each element, whereas calling it on, say, an `Array` value returns the `Array` notation of type (which looks for the largest common type among the values, up to `Any`):
+`typeof()` is notable for treating tuples differently from most other collections. Calling `typeof()` on a tuple enumerates the types of each element, whereas calling it on, say, an `Array` value returns the `Array` notation of type (which looks for the most specific common type among the values, up to `Any`):
 
 ```julia
 	julia> typeof([1, 2, "a"])


### PR DESCRIPTION
I think the definition of a "largest" type is vague - the wording would be more precise if it stated "most specific common type among the values, up to Any".