### PR TITLE
UNSHIFT AND SHIFT

### DIFF
--- a/_chapters/07-ex4.md
+++ b/_chapters/07-ex4.md
@@ -187,20 +187,20 @@ Unpacking can also be used to swap the contents of variables:
 ```
 
 
-#### `shift!` and `unshift!`
+#### `pushfirst!` and `popfirst!`
 
-`shift!` and `unshift!` are the front equivalent of `pop!` and `push!`.
-Similarly to `pop!`, `shift!` retrieves the first element of the collection and removes it from the collection (which *shifts* it):
+`popfirst!` and `pushfirst!` are the front equivalent of `pop!` and `push!` as of Julia 1.6.1.
+Similarly to `pop!`, `popfirst!` retrieves the first element of the collection and removes it from the collection (which *shifts* it):
 
 ```julia
-	julia> shift!(array)
+	julia> popfirst!(array)
 	1
 ```
 
-Similarly to `push!`, `unshift!` puts an element to the front of the collection:
+Similarly to `push!`, `pushfirst!` puts an element to the front of the collection:
 
 ```julia
-	julia> unshift!(array, 8)
+	julia> pushfirst!(array, 8)
 	7-element Array{Int64,1}:
 	 8
 	 2


### PR DESCRIPTION
Unshift and shift are **deprecated** as of Julia 1.6.1 April 23,2021. "shift" and "unshift" were replaced/renamed to **[_popfirst_](https://github.com/JuliaLang/julia/blob/1b93d53fc4bb59350ada898038ed4de2994cce33/base/array.jl#L1258-L1285)** and **[_pushfirst_](https://github.com/JuliaLang/julia/blob/1b93d53fc4bb59350ada898038ed4de2994cce33/base/array.jl#L1234-L1250)** respectively.