### PR TITLE
Update info and warn section to reflect new macro log system

### DIFF
--- a/_chapters/11-ex8.md
+++ b/_chapters/11-ex8.md
@@ -153,15 +153,18 @@ It's good practice to ensure that teardown operations are executed regardless of
 
 ### `info` and `warn`
 
-We have seen that calling `error` will interrupt execution. What, however, if we just want to display a warning or an informational message without interrupting execution, as is common in debugging code? Julia provides the `info` and `warn` functions, which allow for the display of notifications without raising an interrupt:
+We have seen that calling `error` will interrupt execution. What, however, if we just want to display a warning or an informational message without interrupting execution, as is common in debugging code? Julia provides the `@info` and `@warn` macros, which allow for the display of notifications without raising an interrupt:
 
 ```julia
-	julia> info("This code is looking pretty good.")
-	INFO: This code is looking pretty good.
+	julia> @info "This code is looking pretty good."
+	[ Info: This code is looking pretty good.
 
-	julia> warn("You're not looking too good. Best check yourself.")
-	WARNING: You're not looking too good. Best check yourself.
+	julia> @warn "You're not looking too good. Best check yourself."
+	┌ Warning: You're not looking too good. Best check yourself.
+        └ @ Main REPL[2]:1
 ```
+
+See [Logging](https://docs.julialang.org/en/v1/stdlib/Logging/) in the Julia documentation for more information.
 
 ### `rethrow`, `backtrace` and `catch_backtrace`
 


### PR DESCRIPTION
Julia no longer uses functions (at least in the public API) for logging. The code in the current version of the book is broken:

```julia
julia> warn("You're not looking too good. Best check yourself.")
ERROR: UndefVarError: `warn` not defined
Stacktrace:
 [1] top-level scope
   @ REPL[9]:1
```

Now, messages are emitted by the macro [`@logmsg`](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.@logmsg) (and its variants `@info`, `@warn`, and `@debug`). I [updated this section](https://github.com/chrisvoncsefalvay/learn-julia-the-hard-way/pull/75/commits/b2a041593127bad2c35415f6bc16b5b028121e14) to reflect the change.